### PR TITLE
[ci] Changing port number to reflect the service metadata.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
       CERTS_DIR: singnet/.certs
       SERVICE_RUN_COMMAND: bash -c "git pull;python3.6 run_service.py --ssl"
       SERVICE_TEST_COMMAND: bash -c "sleep 10;python3.6 test_service.py auto"
-      SNETD_PORT_MAINNET: 6206
+      SNETD_PORT_MAINNET: 6406
       SNETD_PORT_ROPSTEN: 6306
     steps:
       - checkout

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -2,6 +2,6 @@ registry = {
     'mask_rcnn_server': {
         'grpc': 6006,
         'jsonrpc': 6106,
-        'snetd': 6206,
+        'snetd': 6406,
     },
 }


### PR DESCRIPTION
- Service's port on Mainnet is `6406`.